### PR TITLE
fix to swift 2.2

### DIFF
--- a/CropViewController/CropRectView.swift
+++ b/CropViewController/CropRectView.swift
@@ -1,3 +1,4 @@
+
 //
 //  CropRectView.swift
 //  CropViewController
@@ -102,11 +103,11 @@ class CropRectView: UIView, ResizeControlDelegate {
         let width = CGRectGetWidth(bounds)
         let height = CGRectGetHeight(bounds)
         
-        for var i = 0; i < 3; i++ {
+        for i in 0 ..< 3 {
             let borderPadding: CGFloat = 2.0
             
             if showsGridMinor {
-                for var j = 1; j < 3; j++ {
+                for j in 1 ..< 3 {
                     UIColor(red: 1.0, green: 1.0, blue: 0.0, alpha: 0.3).set()
                     UIRectFill(CGRect(x: round((width / 9.0) * CGFloat(j) + (width / 3.0) * CGFloat(i)), y: borderPadding, width: 1.0, height: round(height) - borderPadding * 2.0))
                     UIRectFill(CGRect(x: borderPadding, y: round((height / 9.0) * CGFloat(j) + (height / 3.0) * CGFloat(i)), width: round(width) - borderPadding * 2.0, height: 1.0))

--- a/CropViewController/CropView.swift
+++ b/CropViewController/CropView.swift
@@ -133,7 +133,7 @@ public class CropView: UIView, UIScrollViewDelegate, UIGestureRecognizerDelegate
         scrollView.clipsToBounds =  false
         addSubview(scrollView)
         
-        rotationGestureRecognizer = UIRotationGestureRecognizer(target: self, action: "handleRotation:")
+        rotationGestureRecognizer = UIRotationGestureRecognizer(target: self, action: #selector(CropView.handleRotation(_:)))
         rotationGestureRecognizer?.delegate = self
         scrollView.addGestureRecognizer(rotationGestureRecognizer)
         

--- a/CropViewController/CropViewController.swift
+++ b/CropViewController/CropViewController.swift
@@ -87,12 +87,12 @@ public class CropViewController: UIViewController {
 
         navigationController?.navigationBar.translucent = false
         navigationController?.toolbar.translucent = false
-        navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .Cancel, target: self, action: "cancel:")
-        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .Done, target: self, action: "done:")
+        navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .Cancel, target: self, action: #selector(CropViewController.cancel(_:)))
+        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .Done, target: self, action: #selector(CropViewController.done(_:)))
         
         if self.toolbarItems == nil {
             let flexibleSpace = UIBarButtonItem(barButtonSystemItem: .FlexibleSpace, target: nil, action: nil)
-            let constrainButton = UIBarButtonItem(title: "Constrain", style: .Plain, target: self, action: "constrain:")
+            let constrainButton = UIBarButtonItem(title: "Constrain", style: .Plain, target: self, action: #selector(CropViewController.constrain(_:)))
             toolbarItems = [flexibleSpace, constrainButton, flexibleSpace]
         }
         

--- a/CropViewController/ResizeControl.swift
+++ b/CropViewController/ResizeControl.swift
@@ -33,7 +33,7 @@ class ResizeControl: UIView {
         backgroundColor = UIColor.clearColor()
         exclusiveTouch = true
         
-        let gestureRecognizer = UIPanGestureRecognizer(target: self, action: "handlePan:")
+        let gestureRecognizer = UIPanGestureRecognizer(target: self, action: #selector(ResizeControl.handlePan(_:)))
         addGestureRecognizer(gestureRecognizer)
     }
     


### PR DESCRIPTION
warning: use of string literal for Objective-C selectors is deprecated; use '#selector' instead
warning: '++' is deprecated: it will be removed in Swift 3
warning: C-style for statement is deprecated and will be removed in a future version of Swift